### PR TITLE
Rfid full ndef encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,5 @@ MANIFEST
 **.txt
 
 .DS_Store
+venv/
+!requirements.txt

--- a/firewatch/eventlog/rfid_reader.py
+++ b/firewatch/eventlog/rfid_reader.py
@@ -1,0 +1,43 @@
+import ndef
+import random
+import string
+
+class RFIDReader:
+    def __init__(self):
+        """Initialize the RFID Reader Stub."""
+        print("RFID Reader Stub Initialized.")
+
+    def generate_serial_number(self):
+        """Generate a random firearm serial number (10 alphanumeric characters)."""
+        return ''.join(random.choices(string.ascii_uppercase + string.digits, k=10))
+
+    def encode_ndef(self, serial_number):
+        """Encode a firearm serial number into an NDEF message."""
+        ndef_record = ndef.TextRecord(serial_number)
+        ndef_message = list(ndef.message_encoder([ndef_record]))
+        return ndef_message
+
+    def decode_ndef(self, ndef_message):
+        """Decode an NDEF message to extract the firearm serial number."""
+        if isinstance(ndef_message, list):
+            ndef_message = b"".join(ndef_message)  # Convert list to a single bytes object
+        decoded_records = list(ndef.message_decoder(ndef_message))
+        for record in decoded_records:
+            if isinstance(record, ndef.TextRecord):
+                return record.text
+        return None
+
+if __name__ == "__main__":
+    reader = RFIDReader()
+    
+    # Generate a serial number
+    serial_number = reader.generate_serial_number()
+    print("Generated Serial Number:", serial_number)
+
+    # Encode it into NDEF
+    encoded_message = reader.encode_ndef(serial_number)
+    print("Encoded NDEF Message:", encoded_message)
+
+    # Decode the NDEF message
+    decoded_serial = reader.decode_ndef(encoded_message)
+    print("Decoded Serial Number:", decoded_serial)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+ndeflib


### PR DESCRIPTION
Implemented the RFID reader stub for simulating RFID scans and handling NDEF message encoding and decoding.

Key Features Implemented:
- Generates a random firearm serial number (10-character alphanumeric)
- Encodes the serial number into an NDEF message using ndeflib package
- Decodes the NDEF message to retrieve the original firearm serial number
- fixes a previous TypeError where ndef.message_decoder() required a bytes object instead of a list.

Files Changed:
firewatch/eventlog/rfid_reader.py 
.gitignore --> added venv/

How to Test it:
1. Navigate to the eventlog directory (firewatch/eventlog)
2. Run the script: python rfid_reader.py
3. Expected Output:
(venv) (base) lkanjanabout@Lindas-MacBook-Air eventlog % subl rfid_reader.py
(venv) (base) lkanjanabout@Lindas-MacBook-Air eventlog % python rfid_reader.py
RFID Reader Stub Initialized.
Generated Serial Number: TRA2IXQO8Q
Encoded NDEF Message: [b'\xd1\x01\rT\x02enTRA2IXQO8Q']
Decoded Serial Number: TRA2IXQO8Q

4. Verify that the 'Decoded Serial Number' matches the 'Generated Serial Number'